### PR TITLE
working version

### DIFF
--- a/application/docker-compose.yml
+++ b/application/docker-compose.yml
@@ -1,30 +1,18 @@
 version: '3'
 services:
-  stock-app:
-    build: ./stock-app
-    ports:
-      - "5001:5001"
-      - "8000:8000"
-    networks:
-      - app-network
-    volumes:
-      # Use relative path for Linux environments
-      # - ./stock-app/logs:/app/logs
-
-      # Use absolute path for macOS to avoid Docker mount issues
-      - /Users/guyabecassis/Desktop/Guy/Projects/Mid_Project/Mid_Project/stock-app/logs:/app/logs
-    restart: always
-
   prometheus:
-    build: ./prometheus
+    image: gabecasis/prometheus:2
     ports:
       - "9090:9090"
     networks:
       - app-network
     restart: always
+    volumes:
+      - ./prometheus:/prometheus  # Persistent storage for Prometheus data
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml  # Custom Prometheus config
 
   grafana:
-    build: ./grafana
+    image: gabecasis/grafana:2
     ports:
       - "3000:3000"
     networks:
@@ -32,33 +20,10 @@ services:
     restart: always
     volumes:
       - ./grafana:/var/lib/grafana
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources  # Correct datasource path
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards  # Mount dashboards
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
-    depends_on:
-      - loki
-
-  loki:
-    build: ./loki
-    container_name: loki
-    ports:
-      - "3100:3100"
-    networks:
-      - app-network
-    restart: always
-    volumes:
-      - ./loki/config:/etc/loki/config
-      - ./loki/data:/loki
-
-  promtail:
-    build: ./promtail
-    container_name: promtail
-    ports:
-      - "9080:9080"
-    volumes:
-      - ./promtail/config/config.yml:/etc/promtail/config.yml
-      - ./stock-app/logs:/var/log/stock-app
-    networks:
-      - app-network
 
 networks:
   app-network:

--- a/application/prometheus/prometheus.yml
+++ b/application/prometheus/prometheus.yml
@@ -5,4 +5,4 @@ scrape_configs:
   - job_name: 'flask_stock_app'
     metrics_path: /metrics
     static_configs:
-      - targets: ['stock-app:8000']
+      - targets: ['3.94.148.26:8000']

--- a/application/promtail/config/config.yml
+++ b/application/promtail/config/config.yml
@@ -3,16 +3,25 @@ server:
   grpc_listen_port: 0
 
 positions:
-  filename: /tmp/positions.yaml
+  filename: /var/log/positions.yaml
 
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
 scrape_configs:
-  - job_name: stock-app
+  - job_name: system
     static_configs:
       - targets:
           - localhost
         labels:
-          job: stock-app
-          __path__: /var/log/stock-app/stock-app.log
+          job: varlogs
+          __path__: /var/log/*log
+
+  # scrape logs locally from stock-app
+  - job_name: stock-app-logs
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: stock-app-logs
+          __path__: /home/ec2-user/stock-app/logs/*.log

--- a/application/stock-app/app.py
+++ b/application/stock-app/app.py
@@ -27,7 +27,7 @@ logging.basicConfig(
 )
 
 # MongoDB client setup
-mongo_uri = os.getenv("MONGO_URI", "mongodb://root:password@44.198.185.66:27017")
+mongo_uri = os.getenv("MONGO_URI", "mongodb://root:password@3.234.223.63:27017")
 client = MongoClient(mongo_uri)
 db = client.stock_app_db  # Use or create a database
 stocks_collection = db.stocks  # Use or create a collection

--- a/application/stock-app/docker-compose.yml
+++ b/application/stock-app/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3'
+services:
+  promtail:
+    image: gabecasis/promtail:2
+    container_name: promtail
+    ports:
+      - "9080:9080"
+    volumes:
+      - ./promtail/config/config.yml:/etc/promtail/config.yml
+      - /home/ec2-user/stock-app/logs:/home/ec2-user/stock-app/logs  # Correctly map stock-app logs for Promtail
+    networks:
+      - app-network
+
+
+  stock-app:
+    image: gabecasis/stock-app:4
+    ports:
+      - "5001:5001"
+      - "8000:8000"
+    environment:
+      MONGO_URI: ${MONGO_URI}
+    volumes:
+      - /home/ec2-user/stock-app/logs:/app/logs  # Maps the container’s logs directory to a host directory
+    command: ["--mongo_uri", "${MONGO_URI}"]
+    networks:
+      - app-network
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    ports:
+      - "3100:3100"
+    networks:
+      - app-network
+    restart: always
+
+networks:
+  app-network:
+    driver: bridge

--- a/application/stock-app/requirements.txt
+++ b/application/stock-app/requirements.txt
@@ -1,4 +1,6 @@
 Flask
 yfinance
+numpy
 scikit-learn
 prometheus_client
+pymongo

--- a/application/userdata.sh
+++ b/application/userdata.sh
@@ -13,61 +13,551 @@ sudo curl -L "https://github.com/docker/compose/releases/download/v2.21.0/docker
 chmod +x /usr/local/bin/docker-compose
 
 # Create necessary directories for volumes
-mkdir -p /home/ec2-user/prometheus /home/ec2-user/prometheus/config
-mkdir -p /home/ec2-user/prometheus/data
-mkdir -p /home/ec2-user/grafana
-mkdir -p /home/ec2-user/loki/data
-mkdir -p /home/ec2-user/promtail
+mkdir -p /home/ec2-user/prometheus /home/ec2-user/prometheus/config /home/ec2-user/prometheus/data
+mkdir -p /home/ec2-user/grafana /home/ec2-user/grafana/provisioning /home/ec2-user/grafana/provisioning/dashboards /home/ec2-user/grafana/provisioning/datasources
 
 # Change ownership of directories to ec2-user
 chown -R ec2-user:ec2-user /home/ec2-user/*
-
 chown -R 65534:65534 /home/ec2-user/prometheus  # Ensure Prometheus has permission to write to the directory
-
+sudo chown -R 472:472 ./grafana
+sudo chmod -R 755 ./grafana
 
 # Create the Prometheus configuration file
 cat <<EOF > /home/ec2-user/prometheus/prometheus.yml
 global:
   scrape_interval: 15s
-  evaluation_interval: 15s
 
 scrape_configs:
-  - job_name: 'prometheus'
+  - job_name: 'flask_stock_app'
+    metrics_path: /metrics
     static_configs:
-      - targets: ['44.222.140.65:9090']
-  - job_name: 'loki'
-    static_configs:
-      - targets: ['44.222.140.65:3100']
+      - targets: ['3.94.148.26:8000']
 EOF
 
-# Create the Promtail configuration file
-cat <<EOF > /home/ec2-user/promtail/config/config.yml
-server:
-  http_listen_port: 9080
-  grpc_listen_port: 0
+# Set Grafana datasource configuration file to pull from prometheus and loki
+cat <<EOF > /home/ec2-user/grafana/provisioning/datasources/datasources.yml
+apiVersion: 1
 
-positions:
-  filename: /var/log/positions.yaml
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    isDefault: true
+    version: 1
+    editable: true
 
-clients:
-  - url: http://loki:3100/loki/api/v1/push
-
-scrape_configs:
-- job_name: system
-  static_configs:
-  - targets:
-      - localhost
-    labels:
-      job: varlogs
-      __path__: /var/log/*log
+  - name: Loki
+    type: loki
+    access: proxy
+    orgId: 1
+    url: http://3.94.148.26:3100
+    isDefault: false
+    version: 1
+    editable: true
 EOF
 
-# Change ownership of the Grafana directory to ensure it can be written to by Grafana inside the container
-chown -R 472:472 /home/ec2-user/grafana
 
-# Change ownership of all other directories to ec2-user
-chown -R ec2-user:ec2-user /home/ec2-user/prometheus /home/ec2-user/loki /home/ec2-user/promtail
+# Create the Grafana Loki dashboard file
+cat <<EOF > /home/ec2-user/grafana/provisioning/dashboards/loki_dashboard.json
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "panels": [
+    {
+      "datasource": "Loki",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{job=\"flask_stock_app\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Loki Log Stream",
+      "type": "logs"
+    }
+  ],
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Loki Logs",
+  "uid": "loki-logs",
+  "version": 1
+}
+EOF
 
+
+
+# Create the Grafana dashboard for stock file
+cat <<EOF > /home/ec2-user/grafana/provisioning/dashboards/stock-app_dashboard.json
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 15956,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0
+              },
+              {
+                "color": "#299c46",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.0",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "current_stock_value",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "{{stock}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Ticker",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 20,
+        "x": 4,
+        "y": 0
+      },
+      "id": 138,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "current_stock_value",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "{{stock}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "All stock values",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 15,
+      "panels": [],
+      "repeat": "target",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "$target ",
+      "type": "row"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [
+    "blackbox",
+    "prometheus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "auto": true,
+        "auto_count": 10,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "text": "10s",
+          "value": "10s"
+        },
+        "hide": 0,
+        "label": "Interval",
+        "name": "interval",
+        "options": [
+          {
+            "selected": false,
+            "text": "auto",
+            "value": "$__auto_interval_interval"
+          },
+          {
+            "selected": false,
+            "text": "5s",
+            "value": "5s"
+          },
+          {
+            "selected": true,
+            "text": "10s",
+            "value": "10s"
+          },
+          {
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "5s,10s,30s,1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "label_values(stock_price, stock_symbol)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "target",
+        "options": [],
+        "query": {
+          "query": "label_values(stock_price, stock_symbol)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Stock dashboard",
+  "uid": "ferebtebh3",
+  "version": 1,
+  "weekStart": ""
+}
+EOF
 
 # Create Docker Compose file
 cat <<EOF > /home/ec2-user/docker-compose.yml
@@ -93,36 +583,15 @@ services:
     restart: always
     volumes:
       - ./grafana:/var/lib/grafana
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources  # Correct datasource path
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards  # Mount dashboards
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
-    depends_on:
-      - loki
-
-  loki:
-    image: gabecasis/loki:2
-    container_name: loki
-    ports:
-      - "3100:3100"
-    networks:
-      - app-network
-    restart: always
-    volumes:
-      - ./loki/data:/loki
-
-  promtail:
-    image: gabecasis/promtail:2
-    container_name: promtail
-    ports:
-      - "9080:9080"
-    volumes:
-      - ./promtail/config/config.yml:/etc/promtail/config.yml
-      - ./loki/data:/var/log/loki
-    networks:
-      - app-network
 
 networks:
   app-network:
     driver: bridge
+
 EOF
 
 # Navigate to the directory and bring up the services


### PR DESCRIPTION
1. userdata.sh for stock-app + promtail + loki.
2. userdata.sh for prometheus + grafana.

Order of things:
1. ramp-up the mongo ec2 instance using the /mongo/userdata.sh. Make sure you save the mongo ip --> <mongo-ip>
2. ramp up the webapp ec2 instance using the /stock-app/userdata.sh.  The stock-app should get the <mongo-ip> in the app.py and in the userdata.sh --> save the <stock-app-ip>
3. ramp up the monitoring ec2 instance using the application/userdata.sh. make sure you config the <stock-app-ip> in the prometheus scraping and in the grafan.